### PR TITLE
Add test suite with 158 tests covering const, nea, init, and sensor modules

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,34 @@
+name: Tests
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install test dependencies
+        run: pip install -r requirements-test.txt
+
+      - name: Run tests
+        run: pytest tests/ -v --tb=short
+
+      - name: Run tests with coverage report
+        if: matrix.python-version == '3.11'
+        run: |
+          pip install pytest-cov
+          pytest tests/ --cov=custom_components/nea_sg_weather --cov-report=term-missing

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.py[cod]
+.pytest_cache/
+.coverage
+htmlcov/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,72 @@
+# NEA Singapore Weather — Developer Guide
+
+## Project Overview
+
+Home Assistant custom integration providing real-time weather data for Singapore via the NEA / data.gov.sg API.
+
+## Running the Test Suite
+
+Install test dependencies:
+
+```bash
+pip install -r requirements-test.txt
+```
+
+Run all tests:
+
+```bash
+pytest
+```
+
+Run with verbose output:
+
+```bash
+pytest -v
+```
+
+Run a specific test file:
+
+```bash
+pytest tests/test_nea.py -v
+```
+
+Run with coverage:
+
+```bash
+pip install pytest-cov
+pytest --cov=custom_components/nea_sg_weather --cov-report=term-missing
+```
+
+## Test Architecture
+
+Tests live in `tests/` and are structured by source module:
+
+| File | Tests for |
+|---|---|
+| `tests/conftest.py` | Home Assistant module stubs (applied globally) |
+| `tests/test_const.py` | Constants, mappings, area/region lists, endpoints |
+| `tests/test_nea.py` | API wrapper data-processing logic (`nea.py`) |
+| `tests/test_init.py` | `get_platforms()` platform selection logic |
+| `tests/test_sensor.py` | Sensor entity properties and formatting |
+
+Since this integration depends on Home Assistant, `tests/conftest.py` patches
+`sys.modules` with lightweight stubs before any source imports happen. No full
+HA installation is needed to run the tests.
+
+## Source Layout
+
+```
+custom_components/nea_sg_weather/
+├── __init__.py       # Coordinator setup, get_platforms()
+├── const.py          # All constants: areas, regions, condition maps, endpoints
+├── nea.py            # Async API wrappers (Forecast2hr, Wind, Rain, …)
+├── weather.py        # WeatherEntity
+├── sensor.py         # Sensor entities (area, region, rain, UV, PM2.5)
+├── camera.py         # Rain-map camera entities
+└── config_flow.py    # Config-entry UI flow
+```
+
+## CI
+
+GitHub Actions (`.github/workflows/tests.yml`) runs the suite on Python 3.11
+and 3.12 for every push to `main`/`master` and every pull request.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+asyncio_mode = auto

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,2 @@
+pytest>=7.4
+pytest-asyncio>=0.23

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,136 @@
+"""Configure pytest with Home Assistant module stubs."""
+import sys
+import os
+from unittest.mock import MagicMock
+
+# Ensure project root is importable
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+# ---------------------------------------------------------------------------
+# Stub base classes so HA entity classes can be inherited normally
+# ---------------------------------------------------------------------------
+
+class _CoordinatorEntity:
+    def __init__(self, coordinator=None):
+        self.coordinator = coordinator
+
+
+class _DataUpdateCoordinator:
+    def __init__(self, *args, **kwargs):
+        pass
+
+
+class _SensorEntity:
+    pass
+
+
+class _WeatherEntity:
+    pass
+
+
+class _CameraEntity:
+    pass
+
+
+# ---------------------------------------------------------------------------
+# homeassistant.components.weather
+# ---------------------------------------------------------------------------
+_ha_weather = MagicMock()
+_ha_weather.ATTR_CONDITION_CLEAR_NIGHT = "clear-night"
+_ha_weather.ATTR_CONDITION_CLOUDY = "cloudy"
+_ha_weather.ATTR_CONDITION_FOG = "fog"
+_ha_weather.ATTR_CONDITION_LIGHTNING = "lightning"
+_ha_weather.ATTR_CONDITION_LIGHTNING_RAINY = "lightning-rainy"
+_ha_weather.ATTR_CONDITION_PARTLYCLOUDY = "partlycloudy"
+_ha_weather.ATTR_CONDITION_POURING = "pouring"
+_ha_weather.ATTR_CONDITION_RAINY = "rainy"
+_ha_weather.ATTR_CONDITION_SNOWY = "snowy"
+_ha_weather.ATTR_CONDITION_SNOWY_RAINY = "snowy-rainy"
+_ha_weather.ATTR_CONDITION_SUNNY = "sunny"
+_ha_weather.ATTR_CONDITION_WINDY = "windy"
+_ha_weather.ATTR_CONDITION_WINDY_VARIANT = "windy-variant"
+_ha_weather.ATTR_FORECAST_CONDITION = "condition"
+_ha_weather.ATTR_FORECAST_NATIVE_TEMP = "native_temperature"
+_ha_weather.ATTR_FORECAST_NATIVE_TEMP_LOW = "native_templow"
+_ha_weather.ATTR_FORECAST_NATIVE_WIND_SPEED = "native_wind_speed"
+_ha_weather.ATTR_FORECAST_TIME = "datetime"
+_ha_weather.ATTR_FORECAST_WIND_BEARING = "wind_bearing"
+_ha_weather.WeatherEntity = _WeatherEntity
+_ha_weather.WeatherEntityFeature = MagicMock()
+_ha_weather.WeatherEntityFeature.FORECAST_DAILY = 1
+_ha_weather.Forecast = dict
+
+# ---------------------------------------------------------------------------
+# homeassistant.components.sensor
+# ---------------------------------------------------------------------------
+_ha_sensor = MagicMock()
+_ha_sensor.SensorDeviceClass = MagicMock()
+_ha_sensor.SensorDeviceClass.PM25 = "pm25"
+_ha_sensor.SensorDeviceClass.PRECIPITATION = "precipitation"
+_ha_sensor.SensorEntity = _SensorEntity
+_ha_sensor.SensorStateClass = MagicMock()
+_ha_sensor.SensorStateClass.MEASUREMENT = "measurement"
+
+# ---------------------------------------------------------------------------
+# homeassistant.const
+# ---------------------------------------------------------------------------
+_ha_const = MagicMock()
+_ha_const.CONF_NAME = "name"
+_ha_const.CONF_SCAN_INTERVAL = "scan_interval"
+_ha_const.CONF_SENSORS = "sensors"
+_ha_const.CONF_TIMEOUT = "timeout"
+_ha_const.CONF_REGION = "region"
+_ha_const.CONF_PREFIX = "prefix"
+_ha_const.CONF_SELECTOR = "selector"
+_ha_const.UnitOfTemperature = MagicMock()
+_ha_const.UnitOfTemperature.CELSIUS = "°C"
+_ha_const.UnitOfLength = MagicMock()
+_ha_const.UnitOfLength.MILLIMETERS = "mm"
+_ha_const.UnitOfPressure = MagicMock()
+_ha_const.UnitOfPressure.HPA = "hPa"
+_ha_const.UnitOfSpeed = MagicMock()
+_ha_const.UnitOfSpeed.KNOTS = "kn"
+_ha_const.UnitOfPrecipitationDepth = MagicMock()
+_ha_const.UnitOfPrecipitationDepth.MILLIMETERS = "mm"
+
+# ---------------------------------------------------------------------------
+# homeassistant.helpers.update_coordinator
+# ---------------------------------------------------------------------------
+_ha_coordinator = MagicMock()
+_ha_coordinator.DataUpdateCoordinator = _DataUpdateCoordinator
+_ha_coordinator.CoordinatorEntity = _CoordinatorEntity
+_ha_coordinator.UpdateFailed = Exception
+
+# ---------------------------------------------------------------------------
+# homeassistant.components.camera
+# ---------------------------------------------------------------------------
+_ha_camera = MagicMock()
+_ha_camera.Camera = _CameraEntity
+
+# ---------------------------------------------------------------------------
+# Patch sys.modules before any source imports happen
+# ---------------------------------------------------------------------------
+sys.modules.update({
+    "homeassistant": MagicMock(),
+    "homeassistant.components": MagicMock(),
+    "homeassistant.components.weather": _ha_weather,
+    "homeassistant.components.sensor": _ha_sensor,
+    "homeassistant.components.camera": _ha_camera,
+    "homeassistant.config_entries": MagicMock(),
+    "homeassistant.const": _ha_const,
+    "homeassistant.core": MagicMock(),
+    "homeassistant.helpers": MagicMock(),
+    "homeassistant.helpers.aiohttp_client": MagicMock(),
+    "homeassistant.helpers.httpx_client": MagicMock(),
+    "homeassistant.helpers.update_coordinator": _ha_coordinator,
+    "homeassistant.helpers.device_registry": MagicMock(),
+    "homeassistant.helpers.entity_platform": MagicMock(),
+    "homeassistant.helpers.config_validation": MagicMock(),
+    "aiohttp": MagicMock(),
+    "voluptuous": MagicMock(),
+    "PIL": MagicMock(),
+    "PIL.Image": MagicMock(),
+    "PIL.ImageDraw": MagicMock(),
+    "PIL.ImageFont": MagicMock(),
+})

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -1,0 +1,191 @@
+"""Tests for custom_components/nea_sg_weather/const.py"""
+import pytest
+from custom_components.nea_sg_weather.const import (
+    AREAS,
+    CONF_AREAS,
+    CONF_RAIN,
+    CONF_SENSOR,
+    CONF_WEATHER,
+    DEFAULT_NAME,
+    DEFAULT_SCAN_INTERVAL,
+    DEFAULT_TIMEOUT,
+    DOMAIN,
+    FORECAST_ICON_MAP_CONDITION,
+    FORECAST_MAP_CONDITION,
+    MAP_CONDITION,
+    PRIMARY_ENDPOINTS,
+    RAIN_SENSOR_LIST,
+    REGIONS,
+    SECONDARY_ENDPOINTS,
+    ATTRIBUTION,
+)
+
+
+class TestDomainConstants:
+    def test_domain(self):
+        assert DOMAIN == "nea_sg_weather"
+
+    def test_default_name(self):
+        assert DEFAULT_NAME == "Singapore Weather"
+
+    def test_default_scan_interval(self):
+        assert DEFAULT_SCAN_INTERVAL == 15
+
+    def test_default_timeout(self):
+        assert DEFAULT_TIMEOUT == 60
+
+    def test_attribution(self):
+        assert "NEA" in ATTRIBUTION
+
+    def test_conf_values(self):
+        assert CONF_WEATHER == "weather"
+        assert CONF_SENSOR == "sensor"
+        assert CONF_AREAS == "areas"
+        assert CONF_RAIN == "rain"
+
+
+class TestAreas:
+    def test_areas_count(self):
+        assert len(AREAS) == 47
+
+    def test_areas_no_duplicates(self):
+        assert len(AREAS) == len(set(AREAS))
+
+    def test_areas_contains_expected(self):
+        for area in ["Ang Mo Kio", "Bedok", "Changi", "Jurong East", "Woodlands", "Yishun"]:
+            assert area in AREAS
+
+    def test_areas_are_strings(self):
+        assert all(isinstance(a, str) for a in AREAS)
+
+
+class TestRegions:
+    def test_regions_count(self):
+        assert len(REGIONS) == 5
+
+    def test_regions_values(self):
+        for region in ["West", "East", "Central", "South", "North"]:
+            assert region in REGIONS
+
+    def test_regions_no_duplicates(self):
+        assert len(REGIONS) == len(set(REGIONS))
+
+
+class TestMapCondition:
+    def test_all_conditions_have_ha_mapping(self):
+        # All values should be non-empty strings (HA condition names)
+        for key, value in MAP_CONDITION.items():
+            assert isinstance(value, str), f"{key!r} maps to non-string: {value!r}"
+            assert len(value) > 0
+
+    def test_key_conditions_present(self):
+        assert "Sunny" in MAP_CONDITION
+        assert "Cloudy" in MAP_CONDITION
+        assert "Thundery Showers" in MAP_CONDITION
+        assert "Heavy Rain" in MAP_CONDITION
+        assert "Hazy" in MAP_CONDITION
+        assert "Partly Cloudy" in MAP_CONDITION
+
+    def test_sunny_maps_to_sunny(self):
+        assert MAP_CONDITION["Sunny"] == "sunny"
+
+    def test_heavy_rain_maps_to_pouring(self):
+        assert MAP_CONDITION["Heavy Rain"] == "pouring"
+
+    def test_thundery_showers_maps_to_lightning(self):
+        assert MAP_CONDITION["Thundery Showers"] == "lightning-rainy"
+
+    def test_hazy_maps_to_fog(self):
+        assert MAP_CONDITION["Hazy"] == "fog"
+
+    def test_partly_cloudy_maps_to_partlycloudy(self):
+        assert MAP_CONDITION["Partly Cloudy"] == "partlycloudy"
+
+
+class TestForecastIconMapCondition:
+    def test_same_keys_as_map_condition(self):
+        assert set(FORECAST_ICON_MAP_CONDITION.keys()) == set(MAP_CONDITION.keys())
+
+    def test_values_are_two_char_codes(self):
+        for key, value in FORECAST_ICON_MAP_CONDITION.items():
+            assert isinstance(value, str), f"{key!r} has non-string code"
+            assert len(value) == 2, f"{key!r} code {value!r} is not 2 chars"
+
+    def test_sunny_icon_code(self):
+        assert FORECAST_ICON_MAP_CONDITION["Sunny"] == "SU"
+
+    def test_cloudy_icon_code(self):
+        assert FORECAST_ICON_MAP_CONDITION["Cloudy"] == "CL"
+
+    def test_no_duplicate_values(self):
+        values = list(FORECAST_ICON_MAP_CONDITION.values())
+        # Some conditions share codes (e.g. "Partly Cloudy" and "Partly Cloudy (Day)")
+        # so we just verify there are no None values
+        assert all(v is not None for v in values)
+
+
+class TestForecastMapCondition:
+    def test_keys_are_lowercase(self):
+        for key in FORECAST_MAP_CONDITION.keys():
+            assert key == key.lower(), f"Key {key!r} is not lowercase"
+
+    def test_contains_thundery_showers(self):
+        assert "thundery showers" in FORECAST_MAP_CONDITION
+
+    def test_contains_fair(self):
+        assert "fair" in FORECAST_MAP_CONDITION
+
+    def test_values_are_strings(self):
+        for k, v in FORECAST_MAP_CONDITION.items():
+            assert isinstance(v, str), f"{k!r} maps to non-string"
+
+
+class TestRainSensorList:
+    def test_sensor_count(self):
+        assert len(RAIN_SENSOR_LIST) > 0
+
+    def test_each_sensor_has_required_fields(self):
+        for sensor in RAIN_SENSOR_LIST:
+            assert "id" in sensor, f"Sensor missing 'id': {sensor}"
+            assert "name" in sensor, f"Sensor missing 'name': {sensor}"
+            assert "location" in sensor, f"Sensor missing 'location': {sensor}"
+            assert "latitude" in sensor["location"]
+            assert "longitude" in sensor["location"]
+
+    def test_location_values_are_singapore_coordinates(self):
+        # Singapore latitude: ~1.2–1.5, longitude: ~103.6–104.1
+        for sensor in RAIN_SENSOR_LIST:
+            lat = sensor["location"]["latitude"]
+            lon = sensor["location"]["longitude"]
+            assert 1.1 <= lat <= 1.5, f"{sensor['id']} lat {lat} outside Singapore range"
+            assert 103.5 <= lon <= 104.2, f"{sensor['id']} lon {lon} outside Singapore range"
+
+    def test_sensor_ids_are_unique(self):
+        ids = [s["id"] for s in RAIN_SENSOR_LIST]
+        assert len(ids) == len(set(ids))
+
+    def test_known_sensors_present(self):
+        ids = {s["id"] for s in RAIN_SENSOR_LIST}
+        for expected in ["S77", "S109", "S107", "S81"]:
+            assert expected in ids
+
+
+class TestEndpoints:
+    def test_primary_endpoints_keys(self):
+        required = {
+            "forecast2hr", "forecast24hr", "temperature", "humidity",
+            "wind-direction", "wind-speed", "forecast4day", "rainfall",
+            "uv-index", "pm25",
+        }
+        assert set(PRIMARY_ENDPOINTS.keys()) == required
+
+    def test_primary_endpoints_are_https(self):
+        for key, url in PRIMARY_ENDPOINTS.items():
+            assert url.startswith("https://"), f"{key} endpoint not HTTPS: {url}"
+
+    def test_secondary_endpoints_same_keys(self):
+        assert set(SECONDARY_ENDPOINTS.keys()) == set(PRIMARY_ENDPOINTS.keys())
+
+    def test_primary_endpoints_use_data_gov_sg(self):
+        for key, url in PRIMARY_ENDPOINTS.items():
+            assert "data.gov.sg" in url, f"{key} does not use data.gov.sg: {url}"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,127 @@
+"""Tests for custom_components/nea_sg_weather/__init__.py"""
+import pytest
+from unittest.mock import MagicMock
+
+from custom_components.nea_sg_weather import get_platforms
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_config_entry(
+    weather=True,
+    sensor=False,
+    areas=None,
+    region=False,
+    rain=False,
+):
+    """Build a minimal mock ConfigEntry."""
+    config_entry = MagicMock()
+    config_entry.data = {
+        "weather": weather,
+        "sensor": sensor,
+        "sensors": {
+            "areas": areas if areas is not None else ["None"],
+            "region": region,
+            "rain": rain,
+            "prefix": "nea",
+        },
+    }
+    return config_entry
+
+
+# ---------------------------------------------------------------------------
+# get_platforms
+# ---------------------------------------------------------------------------
+
+class TestGetPlatforms:
+    def test_weather_only_adds_weather_platform(self):
+        result = get_platforms(_make_config_entry(weather=True, sensor=False))
+        assert "weather" in result["platforms"]
+
+    def test_weather_only_no_sensor_platform(self):
+        result = get_platforms(_make_config_entry(weather=True, sensor=False))
+        assert "sensor" not in result["platforms"]
+        assert "camera" not in result["platforms"]
+
+    def test_no_entities_empty_platforms(self):
+        result = get_platforms(_make_config_entry(weather=False, sensor=False))
+        assert len(result["platforms"]) == 0
+        assert len(result["entities"]) == 0
+
+    def test_sensor_areas_adds_sensor_platform(self):
+        result = get_platforms(_make_config_entry(
+            weather=False, sensor=True, areas=["Ang Mo Kio"]
+        ))
+        assert "sensor" in result["platforms"]
+
+    def test_sensor_areas_none_no_sensor(self):
+        result = get_platforms(_make_config_entry(
+            weather=False, sensor=True, areas=["None"]
+        ))
+        assert "sensor" not in result["platforms"]
+
+    def test_sensor_region_adds_sensor_platform(self):
+        result = get_platforms(_make_config_entry(
+            weather=False, sensor=True, areas=["None"], region=True
+        ))
+        assert "sensor" in result["platforms"]
+
+    def test_rain_adds_camera_platform(self):
+        result = get_platforms(_make_config_entry(
+            weather=False, sensor=True, areas=["None"], rain=True
+        ))
+        assert "camera" in result["platforms"]
+
+    def test_all_enabled_all_platforms(self):
+        result = get_platforms(_make_config_entry(
+            weather=True, sensor=True, areas=["All"], region=True, rain=True
+        ))
+        for platform in ["weather", "sensor", "camera"]:
+            assert platform in result["platforms"]
+
+    def test_platforms_is_list(self):
+        result = get_platforms(_make_config_entry(weather=True))
+        assert isinstance(result["platforms"], list)
+
+    def test_entities_contains_weather_key(self):
+        result = get_platforms(_make_config_entry(weather=True, sensor=False))
+        assert "weather" in result["entities"]
+
+    def test_entities_contains_areas_key(self):
+        result = get_platforms(_make_config_entry(
+            weather=False, sensor=True, areas=["Bedok"]
+        ))
+        assert "areas" in result["entities"]
+
+    def test_entities_contains_region_key(self):
+        result = get_platforms(_make_config_entry(
+            weather=False, sensor=True, areas=["None"], region=True
+        ))
+        assert "region" in result["entities"]
+
+    def test_entities_contains_rain_key(self):
+        result = get_platforms(_make_config_entry(
+            weather=False, sensor=True, areas=["None"], rain=True
+        ))
+        assert "rain" in result["entities"]
+
+    def test_no_duplicate_platforms(self):
+        result = get_platforms(_make_config_entry(
+            weather=True, sensor=True, areas=["Ang Mo Kio"], region=True, rain=True
+        ))
+        assert len(result["platforms"]) == len(set(result["platforms"]))
+
+    def test_weather_and_sensor_areas(self):
+        result = get_platforms(_make_config_entry(
+            weather=True, sensor=True, areas=["Ang Mo Kio"]
+        ))
+        assert "weather" in result["platforms"]
+        assert "sensor" in result["platforms"]
+
+    def test_all_areas_keyword_adds_sensor(self):
+        result = get_platforms(_make_config_entry(
+            weather=False, sensor=True, areas=["All"]
+        ))
+        assert "sensor" in result["platforms"]

--- a/tests/test_nea.py
+++ b/tests/test_nea.py
@@ -1,0 +1,621 @@
+"""Tests for custom_components/nea_sg_weather/nea.py"""
+import math
+import pytest
+from unittest.mock import MagicMock
+
+from custom_components.nea_sg_weather.nea import (
+    list_mean,
+    Forecast2hr,
+    Forecast24hr,
+    Forecast4day,
+    Temperature,
+    Humidity,
+    UVIndex,
+    PM25,
+    Wind,
+    Rain,
+    WindDirection,
+    WindSpeed,
+)
+
+
+# ---------------------------------------------------------------------------
+# list_mean
+# ---------------------------------------------------------------------------
+
+class TestListMean:
+    def test_all_positive(self):
+        values = [{"value": 10}, {"value": 20}, {"value": 30}]
+        assert list_mean(values) == 20.0
+
+    def test_skips_zero_and_negative(self):
+        # Only positive values (>0) contribute
+        values = [{"value": 0}, {"value": -5}, {"value": 10}, {"value": 20}]
+        assert list_mean(values) == 15.0
+
+    def test_single_value(self):
+        values = [{"value": 5}]
+        assert list_mean(values) == 5.0
+
+    def test_rounds_to_two_decimals(self):
+        values = [{"value": 1}, {"value": 2}]
+        result = list_mean(values)
+        assert result == round(result, 2)
+
+    def test_all_zeros_raises(self):
+        # Division by zero since i stays 0
+        with pytest.raises(ZeroDivisionError):
+            list_mean([{"value": 0}, {"value": 0}])
+
+    def test_fractional_values(self):
+        values = [{"value": 1.5}, {"value": 2.5}]
+        assert list_mean(values) == 2.0
+
+
+# ---------------------------------------------------------------------------
+# Forecast2hr
+# ---------------------------------------------------------------------------
+
+class TestForecast2hr:
+    def _make_resp(self, forecasts, metadata=None):
+        if metadata is None:
+            metadata = [
+                {"label_location": {"latitude": str(1.375 + i * 0.01), "longitude": str(103.839 + i * 0.01)}}
+                for i in range(len(forecasts))
+            ]
+        return {
+            "data": {
+                "items": [{
+                    "timestamp": "2024-01-01T12:00:00+08:00",
+                    "forecasts": forecasts,
+                }],
+                "area_metadata": metadata,
+            }
+        }
+
+    def test_process_data_sets_timestamp(self):
+        f = Forecast2hr()
+        f._resp = self._make_resp([
+            {"area": "Ang Mo Kio", "forecast": "Partly Cloudy"},
+        ])
+        f.process_data()
+        assert f.timestamp == "2024-01-01T12:00:00+08:00"
+
+    def test_process_data_most_common_condition(self):
+        f = Forecast2hr()
+        f._resp = self._make_resp([
+            {"area": "Ang Mo Kio", "forecast": "Partly Cloudy"},
+            {"area": "Bedok", "forecast": "Partly Cloudy"},
+            {"area": "Bishan", "forecast": "Sunny"},
+        ])
+        f.process_data()
+        assert f.current_condition == "Partly Cloudy"
+
+    def test_process_data_area_forecast_populated(self):
+        f = Forecast2hr()
+        f._resp = self._make_resp([
+            {"area": "Ang Mo Kio", "forecast": "Partly Cloudy"},
+            {"area": "Bedok", "forecast": "Sunny"},
+        ])
+        f.process_data()
+        assert "Ang Mo Kio" in f.area_forecast
+        assert "Bedok" in f.area_forecast
+
+    def test_process_data_forecast_value(self):
+        f = Forecast2hr()
+        f._resp = self._make_resp([
+            {"area": "Ang Mo Kio", "forecast": "Partly Cloudy"},
+        ])
+        f.process_data()
+        assert f.area_forecast["Ang Mo Kio"]["forecast"] == "Partly Cloudy"
+
+    def test_process_data_location_converted_to_float(self):
+        f = Forecast2hr()
+        metadata = [{"label_location": {"latitude": "1.375", "longitude": "103.839"}}]
+        f._resp = self._make_resp(
+            [{"area": "Ang Mo Kio", "forecast": "Sunny"}],
+            metadata=metadata,
+        )
+        f.process_data()
+        loc = f.area_forecast["Ang Mo Kio"]["location"]
+        assert isinstance(loc["latitude"], float)
+        assert isinstance(loc["longitude"], float)
+        assert loc["latitude"] == pytest.approx(1.375)
+        assert loc["longitude"] == pytest.approx(103.839)
+
+    def test_process_data_all_same_condition(self):
+        f = Forecast2hr()
+        f._resp = self._make_resp([
+            {"area": "Area A", "forecast": "Sunny"},
+            {"area": "Area B", "forecast": "Sunny"},
+            {"area": "Area C", "forecast": "Sunny"},
+        ])
+        f.process_data()
+        assert f.current_condition == "Sunny"
+
+
+# ---------------------------------------------------------------------------
+# Forecast24hr
+# ---------------------------------------------------------------------------
+
+class TestForecast24hr:
+    def _make_resp(self, periods, timestamp="2024-01-01T00:00:00+08:00"):
+        return {
+            "data": {
+                "records": [{
+                    "timestamp": timestamp,
+                    "periods": periods,
+                }]
+            }
+        }
+
+    def _make_period(self, start_iso, regions):
+        return {
+            "timePeriod": {"start": start_iso},
+            "regions": {r: {"text": v} for r, v in regions.items()},
+        }
+
+    def test_process_data_sets_timestamp(self):
+        f = Forecast24hr()
+        period = self._make_period(
+            "2024-01-01T06:00:00+08:00",
+            {"west": "Partly Cloudy", "east": "Sunny", "central": "Cloudy",
+             "south": "Thundery Showers", "north": "Fair"},
+        )
+        f._resp = self._make_resp([period])
+        f.process_data()
+        assert f.timestamp == "2024-01-01T00:00:00+08:00"
+
+    def test_process_data_all_regions_present(self):
+        f = Forecast24hr()
+        period = self._make_period(
+            "2024-01-01T06:00:00+08:00",
+            {"west": "Partly Cloudy", "east": "Sunny", "central": "Cloudy",
+             "south": "Thundery Showers", "north": "Fair"},
+        )
+        f._resp = self._make_resp([period])
+        f.process_data()
+        for region in ["west", "east", "central", "south", "north"]:
+            assert region in f.region_forecast
+
+    def test_process_data_region_forecast_condition(self):
+        f = Forecast24hr()
+        period = self._make_period(
+            "2024-01-01T06:00:00+08:00",
+            {"west": "Partly Cloudy", "east": "Sunny", "central": "Cloudy",
+             "south": "Thundery Showers", "north": "Fair"},
+        )
+        f._resp = self._make_resp([period])
+        f.process_data()
+        assert f.region_forecast["west"][0][1] == "Partly Cloudy"
+        assert f.region_forecast["east"][0][1] == "Sunny"
+
+    def test_process_data_multiple_periods(self):
+        f = Forecast24hr()
+        periods = [
+            self._make_period(
+                "2024-01-01T06:00:00+08:00",
+                {"west": "Sunny", "east": "Sunny", "central": "Sunny",
+                 "south": "Sunny", "north": "Sunny"},
+            ),
+            self._make_period(
+                "2024-01-01T12:00:00+08:00",
+                {"west": "Cloudy", "east": "Cloudy", "central": "Cloudy",
+                 "south": "Cloudy", "north": "Cloudy"},
+            ),
+        ]
+        f._resp = self._make_resp(periods)
+        f.process_data()
+        assert len(f.region_forecast["west"]) == 2
+
+    def test_process_data_time_of_day_labels(self):
+        f = Forecast24hr()
+        periods = [
+            self._make_period("2024-01-01T06:00:00+08:00",
+                              {"west": "A", "east": "A", "central": "A", "south": "A", "north": "A"}),
+            self._make_period("2024-01-01T12:00:00+08:00",
+                              {"west": "B", "east": "B", "central": "B", "south": "B", "north": "B"}),
+            self._make_period("2024-01-01T18:00:00+08:00",
+                              {"west": "C", "east": "C", "central": "C", "south": "C", "north": "C"}),
+        ]
+        f._resp = self._make_resp(periods)
+        f.process_data()
+        labels = [entry[0] for entry in f.region_forecast["west"]]
+        # Check that the three periods use morning/afternoon/evening labels
+        assert any("morning" in lbl for lbl in labels)
+        assert any("afternoon" in lbl for lbl in labels)
+        assert any("evening" in lbl for lbl in labels)
+
+
+# ---------------------------------------------------------------------------
+# Forecast4day
+# ---------------------------------------------------------------------------
+
+class TestForecast4day:
+    def _make_entry(self, forecast_text, temp_high=33, temp_low=25,
+                    wind_high=20, wind_low=10, wind_dir="NE"):
+        return {
+            "timestamp": "2024-01-02T00:00:00+08:00",
+            "forecast": {"text": forecast_text},
+            "temperature": {"high": temp_high, "low": temp_low},
+            "wind": {"speed": {"high": wind_high, "low": wind_low}, "direction": wind_dir},
+        }
+
+    def _make_resp(self, entries):
+        return {"data": {"records": [{"forecasts": entries}]}}
+
+    def test_process_data_partly_cloudy(self):
+        f = Forecast4day()
+        f._resp = self._make_resp([self._make_entry("Partly cloudy with showers")])
+        f.process_data()
+        assert len(f.forecast) == 1
+        assert f.forecast[0]["condition"] == "partlycloudy"
+
+    def test_process_data_thundery(self):
+        f = Forecast4day()
+        f._resp = self._make_resp([self._make_entry("Thundery showers expected")])
+        f.process_data()
+        assert f.forecast[0]["condition"] == "lightning-rainy"
+
+    def test_process_data_temperature(self):
+        f = Forecast4day()
+        f._resp = self._make_resp([self._make_entry("Fair", temp_high=33, temp_low=25)])
+        f.process_data()
+        assert f.forecast[0]["native_temperature"] == 33
+        assert f.forecast[0]["native_templow"] == 25
+
+    def test_process_data_wind_speed_is_average(self):
+        f = Forecast4day()
+        f._resp = self._make_resp([self._make_entry("Fair", wind_high=20, wind_low=10)])
+        f.process_data()
+        assert f.forecast[0]["native_wind_speed"] == pytest.approx(15.0)
+
+    def test_process_data_wind_direction(self):
+        f = Forecast4day()
+        f._resp = self._make_resp([self._make_entry("Cloudy", wind_dir="SW")])
+        f.process_data()
+        assert f.forecast[0]["wind_bearing"] == "SW"
+
+    def test_process_data_multiple_entries(self):
+        f = Forecast4day()
+        entries = [
+            self._make_entry("Fair"),
+            self._make_entry("Partly cloudy"),
+            self._make_entry("Thundery showers"),
+            self._make_entry("Cloudy"),
+        ]
+        f._resp = self._make_resp(entries)
+        f.process_data()
+        assert len(f.forecast) == 4
+
+    def test_process_data_unknown_condition_skipped(self):
+        f = Forecast4day()
+        # A forecast text that matches no FORECAST_MAP_CONDITION key
+        f._resp = self._make_resp([self._make_entry("Unknown bizarre weather")])
+        f.process_data()
+        assert len(f.forecast) == 0
+
+    def test_process_data_timestamp_stored(self):
+        f = Forecast4day()
+        f._resp = self._make_resp([self._make_entry("Fair")])
+        f.process_data()
+        assert f.forecast[0]["datetime"] == "2024-01-02T00:00:00+08:00"
+
+
+# ---------------------------------------------------------------------------
+# Temperature
+# ---------------------------------------------------------------------------
+
+class TestTemperature:
+    def _make_resp(self, values, timestamp="2024-01-01T12:00:00+08:00"):
+        return {
+            "data": {
+                "readings": [{
+                    "timestamp": timestamp,
+                    "data": [{"value": v} for v in values],
+                }]
+            }
+        }
+
+    def test_process_data_timestamp(self):
+        t = Temperature()
+        t._resp = self._make_resp([28.0, 29.0, 30.0])
+        t.process_data()
+        assert t.timestamp == "2024-01-01T12:00:00+08:00"
+
+    def test_process_data_average(self):
+        t = Temperature()
+        t._resp = self._make_resp([28.0, 30.0])
+        t.process_data()
+        assert t.temp_avg == pytest.approx(29.0)
+
+    def test_process_data_single_station(self):
+        t = Temperature()
+        t._resp = self._make_resp([27.5])
+        t.process_data()
+        assert t.temp_avg == pytest.approx(27.5)
+
+    def test_process_data_multiple_stations(self):
+        t = Temperature()
+        t._resp = self._make_resp([25.0, 26.0, 27.0, 28.0, 29.0])
+        t.process_data()
+        assert t.temp_avg == pytest.approx(27.0)
+
+
+# ---------------------------------------------------------------------------
+# Humidity
+# ---------------------------------------------------------------------------
+
+class TestHumidity:
+    def _make_resp(self, values, timestamp="2024-01-01T12:00:00+08:00"):
+        return {
+            "data": {
+                "readings": [{
+                    "timestamp": timestamp,
+                    "data": [{"value": v} for v in values],
+                }]
+            }
+        }
+
+    def test_process_data_average(self):
+        h = Humidity()
+        h._resp = self._make_resp([80.0, 90.0])
+        h.process_data()
+        assert h.humd_avg == pytest.approx(85.0)
+
+    def test_process_data_empty_list_sets_zero(self):
+        # statistics.fmean on empty list raises StatisticsError, caught -> 0
+        h = Humidity()
+        h._resp = self._make_resp([])
+        h.process_data()
+        assert h.humd_avg == 0
+
+    def test_process_data_timestamp(self):
+        h = Humidity()
+        h._resp = self._make_resp([75.0])
+        h.process_data()
+        assert h.timestamp == "2024-01-01T12:00:00+08:00"
+
+
+# ---------------------------------------------------------------------------
+# UVIndex
+# ---------------------------------------------------------------------------
+
+class TestUVIndex:
+    def _make_resp(self, uv_value, timestamp="2024-01-01T12:00:00+08:00"):
+        return {
+            "data": {
+                "records": [{
+                    "timestamp": timestamp,
+                    "index": [{"value": uv_value}],
+                }]
+            }
+        }
+
+    def test_process_data_uv_index(self):
+        u = UVIndex()
+        u._resp = self._make_resp(7)
+        u.process_data()
+        assert u.uv_index == 7
+
+    def test_process_data_timestamp(self):
+        u = UVIndex()
+        u._resp = self._make_resp(3, timestamp="2024-06-01T10:00:00+08:00")
+        u.process_data()
+        assert u.timestamp == "2024-06-01T10:00:00+08:00"
+
+    def test_process_data_zero_uv(self):
+        u = UVIndex()
+        u._resp = self._make_resp(0)
+        u.process_data()
+        assert u.uv_index == 0
+
+    def test_process_data_high_uv(self):
+        u = UVIndex()
+        u._resp = self._make_resp(12)
+        u.process_data()
+        assert u.uv_index == 12
+
+
+# ---------------------------------------------------------------------------
+# PM25
+# ---------------------------------------------------------------------------
+
+class TestPM25:
+    def _make_resp(self, readings, timestamp="2024-01-01T12:00:00+08:00"):
+        return {
+            "data": {
+                "items": [{
+                    "timestamp": timestamp,
+                    "readings": {
+                        "pm25_one_hourly": readings,
+                    },
+                }]
+            }
+        }
+
+    def test_process_data_stores_readings(self):
+        pm = PM25()
+        readings = {"west": 12, "east": 15, "central": 10, "south": 8, "north": 11}
+        pm._resp = self._make_resp(readings)
+        pm.process_data()
+        assert pm.data == readings
+
+    def test_process_data_timestamp(self):
+        pm = PM25()
+        pm._resp = self._make_resp({"west": 5})
+        pm.process_data()
+        assert pm.timestamp == "2024-01-01T12:00:00+08:00"
+
+    def test_process_data_region_values(self):
+        pm = PM25()
+        readings = {"west": 20, "east": 25, "central": 18, "south": 22, "north": 19}
+        pm._resp = self._make_resp(readings)
+        pm.process_data()
+        assert pm.data["west"] == 20
+        assert pm.data["north"] == 19
+
+
+# ---------------------------------------------------------------------------
+# Wind.calc_wind_status
+# ---------------------------------------------------------------------------
+
+class TestWindCalcStatus:
+    def _wind(self):
+        return Wind()
+
+    def test_single_station_from_north(self):
+        """Wind from north (0°) should produce southward result."""
+        w = self._wind()
+        result = w.calc_wind_status(
+            wind_speed=[{"stationId": "S1", "value": 10}],
+            wind_direction=[{"stationId": "S1", "value": 0}],
+        )
+        assert result["readings_used"] == 1
+        assert result["agg_wind_speed"] == pytest.approx(10.0, rel=1e-5)
+        assert result["agg_wind_direction"] == pytest.approx(180.0, abs=1e-3)
+
+    def test_single_station_from_south(self):
+        """Wind from south (180°) → agg_direction ≈ 0° (or 360°, which is equivalent)."""
+        w = self._wind()
+        result = w.calc_wind_status(
+            wind_speed=[{"stationId": "S1", "value": 10}],
+            wind_direction=[{"stationId": "S1", "value": 180}],
+        )
+        assert result["agg_wind_speed"] == pytest.approx(10.0, rel=1e-5)
+        # 360.0 and 0.0 are equivalent bearings; floating-point may yield either
+        assert result["agg_wind_direction"] % 360 == pytest.approx(0.0, abs=1e-3)
+
+    def test_two_stations_same_direction(self):
+        """Two stations same speed/direction → same avg speed."""
+        w = self._wind()
+        result = w.calc_wind_status(
+            wind_speed=[
+                {"stationId": "S1", "value": 5},
+                {"stationId": "S2", "value": 5},
+            ],
+            wind_direction=[
+                {"stationId": "S1", "value": 90},
+                {"stationId": "S2", "value": 90},
+            ],
+        )
+        assert result["readings_used"] == 2
+        assert result["agg_wind_speed"] == pytest.approx(5.0, rel=1e-5)
+
+    def test_direction_clamped_positive(self):
+        """agg_wind_direction should always be in [0, 360)."""
+        w = self._wind()
+        result = w.calc_wind_status(
+            wind_speed=[{"stationId": "S1", "value": 10}],
+            wind_direction=[{"stationId": "S1", "value": 90}],
+        )
+        assert 0 <= result["agg_wind_direction"] < 360
+
+    def test_mismatched_station_ids_ignored(self):
+        """Station IDs that don't match are not included in the calculation.
+
+        NOTE: When no stations match, readings_used stays 0 and a ZeroDivisionError
+        is raised. This is a known limitation of calc_wind_status — callers must
+        ensure at least one matching station pair exists.
+        """
+        w = self._wind()
+        with pytest.raises(ZeroDivisionError):
+            w.calc_wind_status(
+                wind_speed=[{"stationId": "S1", "value": 10}],
+                wind_direction=[{"stationId": "S99", "value": 0}],
+            )
+
+    def test_result_contains_all_keys(self):
+        w = self._wind()
+        result = w.calc_wind_status(
+            wind_speed=[{"stationId": "S1", "value": 5}],
+            wind_direction=[{"stationId": "S1", "value": 45}],
+        )
+        for key in ["ns_sum", "ns_avg", "ew_sum", "ew_avg", "readings_used",
+                    "agg_wind_speed", "agg_wind_direction"]:
+            assert key in result
+
+    def test_opposing_winds_cancel(self):
+        """Equal-speed opposing stations produce near-zero aggregate speed."""
+        w = self._wind()
+        result = w.calc_wind_status(
+            wind_speed=[
+                {"stationId": "S1", "value": 10},
+                {"stationId": "S2", "value": 10},
+            ],
+            wind_direction=[
+                {"stationId": "S1", "value": 0},    # from north
+                {"stationId": "S2", "value": 180},  # from south
+            ],
+        )
+        assert result["agg_wind_speed"] == pytest.approx(0.0, abs=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# Rain
+# ---------------------------------------------------------------------------
+
+class TestRain:
+    def _make_resp(self, station_readings, timestamp="2024-01-01T12:00:00+08:00"):
+        return {
+            "data": {
+                "readings": [{
+                    "timestamp": timestamp,
+                    "data": station_readings,
+                }]
+            }
+        }
+
+    def test_process_data_timestamp(self):
+        r = Rain()
+        r._resp = self._make_resp([{"stationId": "S77", "value": 1.2}])
+        r.process_data()
+        assert r.timestamp == "2024-01-01T12:00:00+08:00"
+
+    def test_process_data_known_station_value(self):
+        r = Rain()
+        r._resp = self._make_resp([{"stationId": "S77", "value": 2.5}])
+        r.process_data()
+        assert "S77" in r.data
+        assert r.data["S77"]["value"] == 2.5
+
+    def test_process_data_missing_station_defaults_to_zero(self):
+        """Stations absent from API response should be set to 0."""
+        r = Rain()
+        # Provide response with no stations
+        r._resp = self._make_resp([])
+        r.process_data()
+        # All stations in RAIN_SENSOR_LIST should still appear with value 0
+        for station in r.station_list:
+            assert r.data[station["id"]]["value"] == 0
+
+    def test_process_data_station_has_name_and_location(self):
+        r = Rain()
+        r._resp = self._make_resp([{"stationId": "S77", "value": 0.5}])
+        r.process_data()
+        assert "name" in r.data["S77"]
+        assert "location" in r.data["S77"]
+        assert "latitude" in r.data["S77"]["location"]
+        assert "longitude" in r.data["S77"]["location"]
+
+    def test_process_secondary_data_all_zeros(self):
+        r = Rain()
+        r.process_secondary_data()
+        for station in r.station_list:
+            assert r.data[station["id"]]["value"] == 0
+
+    def test_process_secondary_data_all_stations_present(self):
+        r = Rain()
+        r.process_secondary_data()
+        from custom_components.nea_sg_weather.const import RAIN_SENSOR_LIST
+        for station in RAIN_SENSOR_LIST:
+            assert station["id"] in r.data
+
+    def test_process_data_all_stations_present(self):
+        """Every station from RAIN_SENSOR_LIST should be in data after process_data."""
+        r = Rain()
+        r._resp = self._make_resp([])
+        r.process_data()
+        from custom_components.nea_sg_weather.const import RAIN_SENSOR_LIST
+        for station in RAIN_SENSOR_LIST:
+            assert station["id"] in r.data

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,0 +1,329 @@
+"""Tests for custom_components/nea_sg_weather/sensor.py entity classes."""
+import pytest
+from unittest.mock import MagicMock
+
+from custom_components.nea_sg_weather.sensor import (
+    NeaAreaSensor,
+    NeaRegionSensor,
+    NeaRainSensor,
+    NeaUVSensor,
+    NeaPM25Sensor,
+)
+from custom_components.nea_sg_weather.const import FORECAST_ICON_BASE_URL
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+def _make_coordinator(
+    area="Ang Mo Kio",
+    area_forecast_value="Partly Cloudy",
+    area_timestamp="2024-01-01T12:00:00+08:00",
+    region="west",
+    region_forecast=None,
+    region_timestamp="2024-01-01T12:00:00+08:00",
+    rain_station="S77",
+    rain_value=1.2,
+    rain_name="Alexandra Road",
+    rain_timestamp="2024-01-01T12:00:00+08:00",
+    uv_index=5,
+    pm25_data=None,
+):
+    coord = MagicMock()
+    coord.data.forecast2hr.area_forecast = {
+        area: {
+            "forecast": area_forecast_value,
+            "location": {"latitude": 1.375, "longitude": 103.839},
+        }
+    }
+    coord.data.forecast2hr.timestamp = area_timestamp
+    coord.data.forecast24hr.region_forecast = {
+        region: [
+            ["Today morning", "Partly Cloudy"],
+            ["Today afternoon", "Sunny"],
+            ["Today evening", "Cloudy"],
+        ]
+    }
+    coord.data.forecast24hr.timestamp = region_timestamp
+    coord.data.rain.data = {
+        rain_station: {
+            "value": rain_value,
+            "name": rain_name,
+            "location": {"latitude": 1.2937, "longitude": 103.8125},
+        }
+    }
+    coord.data.rain.timestamp = rain_timestamp
+    coord.data.uvindex.uv_index = uv_index
+    coord.data.pm25.data = pm25_data or {"west": 12, "east": 10, "central": 8, "south": 9, "north": 11}
+    return coord
+
+
+def _make_config(prefix="nea"):
+    return {
+        "sensors": {
+            "prefix": prefix,
+            "areas": ["All"],
+            "region": True,
+            "rain": False,
+        }
+    }
+
+
+# ---------------------------------------------------------------------------
+# NeaAreaSensor
+# ---------------------------------------------------------------------------
+
+class TestNeaAreaSensor:
+    def test_unique_id(self):
+        coord = _make_coordinator()
+        sensor = NeaAreaSensor(coord, _make_config("nea"), "Ang Mo Kio", "entry1")
+        assert sensor.unique_id == "nea Ang Mo Kio"
+
+    def test_name(self):
+        coord = _make_coordinator()
+        sensor = NeaAreaSensor(coord, _make_config(), "Bedok", "entry1")
+        assert sensor.name == "Bedok"
+
+    def test_entity_id_lowercase_underscored(self):
+        coord = _make_coordinator(area="Ang Mo Kio")
+        sensor = NeaAreaSensor(coord, _make_config("nea"), "Ang Mo Kio", "entry1")
+        assert sensor.entity_id == "sensor.nea_ang_mo_kio"
+
+    def test_entity_id_prefix_reflected(self):
+        coord = _make_coordinator(area="Bedok")
+        sensor = NeaAreaSensor(coord, _make_config("myprefix"), "Bedok", "entry1")
+        assert "myprefix" in sensor.entity_id
+
+    def test_state_returns_forecast(self):
+        coord = _make_coordinator(area_forecast_value="Thundery Showers")
+        sensor = NeaAreaSensor(coord, _make_config(), "Ang Mo Kio", "entry1")
+        assert sensor.state == "Thundery Showers"
+
+    def test_entity_picture_uses_icon_code(self):
+        coord = _make_coordinator(area_forecast_value="Sunny")
+        sensor = NeaAreaSensor(coord, _make_config(), "Ang Mo Kio", "entry1")
+        # "Sunny" maps to icon code "SU"
+        assert sensor.entity_picture == FORECAST_ICON_BASE_URL + "SU.png"
+
+    def test_entity_picture_unknown_condition_uses_na(self):
+        coord = _make_coordinator(area_forecast_value="Unknown Condition XYZ")
+        sensor = NeaAreaSensor(coord, _make_config(), "Ang Mo Kio", "entry1")
+        assert sensor.entity_picture == FORECAST_ICON_BASE_URL + "NA.png"
+
+    def test_extra_state_attributes_timestamp(self):
+        coord = _make_coordinator(area_timestamp="2024-03-15T08:00:00+08:00")
+        sensor = NeaAreaSensor(coord, _make_config(), "Ang Mo Kio", "entry1")
+        attrs = sensor.extra_state_attributes
+        assert attrs["Updated at"] == "2024-03-15T08:00:00+08:00"
+
+    def test_extra_state_attributes_location(self):
+        coord = _make_coordinator()
+        sensor = NeaAreaSensor(coord, _make_config(), "Ang Mo Kio", "entry1")
+        attrs = sensor.extra_state_attributes
+        assert "latitude" in attrs
+        assert "longitude" in attrs
+        assert attrs["latitude"] == pytest.approx(1.375)
+        assert attrs["longitude"] == pytest.approx(103.839)
+
+    def test_device_info_returns_dict_like(self):
+        coord = _make_coordinator()
+        sensor = NeaAreaSensor(coord, _make_config(), "Ang Mo Kio", "entry1")
+        info = sensor.device_info
+        assert info is not None
+
+
+# ---------------------------------------------------------------------------
+# NeaRegionSensor
+# ---------------------------------------------------------------------------
+
+class TestNeaRegionSensor:
+    def _make_coord(self, region):
+        coord = _make_coordinator(region=region.lower())
+        return coord
+
+    def test_unique_id(self):
+        coord = self._make_coord("West")
+        sensor = NeaRegionSensor(coord, _make_config("nea"), "West", "entry1")
+        assert sensor.unique_id == "nea West"
+
+    def test_name_non_central(self):
+        coord = self._make_coord("West")
+        sensor = NeaRegionSensor(coord, _make_config(), "West", "entry1")
+        assert sensor.name == "Weather in Western Singapore"
+
+    def test_name_central(self):
+        coord = self._make_coord("Central")
+        coord.data.forecast24hr.region_forecast["central"] = [
+            ["Today morning", "Cloudy"]
+        ]
+        sensor = NeaRegionSensor(coord, _make_config(), "Central", "entry1")
+        assert sensor.name == "Weather in Central Singapore"
+
+    def test_name_east(self):
+        coord = self._make_coord("East")
+        coord.data.forecast24hr.region_forecast["east"] = [
+            ["Today morning", "Sunny"]
+        ]
+        sensor = NeaRegionSensor(coord, _make_config(), "East", "entry1")
+        assert sensor.name == "Weather in Eastern Singapore"
+
+    def test_entity_id(self):
+        coord = self._make_coord("North")
+        coord.data.forecast24hr.region_forecast["north"] = [
+            ["Today morning", "Fair"]
+        ]
+        sensor = NeaRegionSensor(coord, _make_config("nea"), "North", "entry1")
+        assert sensor.entity_id == "sensor.nea_north"
+
+    def test_state_first_period(self):
+        coord = self._make_coord("West")
+        sensor = NeaRegionSensor(coord, _make_config(), "West", "entry1")
+        assert sensor.state == "Partly Cloudy"
+
+    def test_extra_state_attributes_includes_periods(self):
+        coord = self._make_coord("West")
+        sensor = NeaRegionSensor(coord, _make_config(), "West", "entry1")
+        attrs = sensor.extra_state_attributes
+        assert "Today morning" in attrs
+        assert "Updated at" in attrs
+
+    def test_extra_state_attributes_timestamp(self):
+        coord = _make_coordinator(region="west", region_timestamp="2024-06-01T06:00:00+08:00")
+        sensor = NeaRegionSensor(coord, _make_config(), "West", "entry1")
+        assert sensor.extra_state_attributes["Updated at"] == "2024-06-01T06:00:00+08:00"
+
+
+# ---------------------------------------------------------------------------
+# NeaRainSensor
+# ---------------------------------------------------------------------------
+
+class TestNeaRainSensor:
+    def test_unique_id(self):
+        coord = _make_coordinator(rain_station="S77")
+        sensor = NeaRainSensor(coord, _make_config("nea"), "S77", "entry1")
+        assert sensor.unique_id == "nea Rainfall S77"
+
+    def test_name(self):
+        coord = _make_coordinator(rain_station="S77")
+        sensor = NeaRainSensor(coord, _make_config(), "S77", "entry1")
+        assert sensor.name == "S77"
+
+    def test_entity_id(self):
+        coord = _make_coordinator(rain_station="S77")
+        sensor = NeaRainSensor(coord, _make_config("nea"), "S77", "entry1")
+        assert sensor.entity_id == "sensor.nea_rainfall_s77"
+
+    def test_native_value(self):
+        coord = _make_coordinator(rain_station="S77", rain_value=2.5)
+        sensor = NeaRainSensor(coord, _make_config(), "S77", "entry1")
+        assert sensor.native_value == 2.5
+
+    def test_icon(self):
+        coord = _make_coordinator()
+        sensor = NeaRainSensor(coord, _make_config(), "S77", "entry1")
+        assert sensor.icon == "mdi:weather-pouring"
+
+    @pytest.mark.parametrize("value,expected_qty", [
+        (0, "0"),
+        (0.1, "0.2"),
+        (0.34, "0.2"),
+        (0.35, "0.5"),
+        (0.74, "0.5"),
+        (0.75, "1"),
+        (1.49, "1"),
+        (1.5, "2"),
+        (2.49, "2"),
+        (2.5, "3"),
+        (3.49, "3"),
+        (3.5, "4"),
+        (4.49, "4"),
+        (4.5, "5"),
+        (10.0, "5"),
+    ])
+    def test_entity_picture_thresholds(self, value, expected_qty):
+        coord = _make_coordinator(rain_station="S77", rain_value=value)
+        sensor = NeaRainSensor(coord, _make_config(), "S77", "entry1")
+        assert sensor.entity_picture == f"/local/weather/{expected_qty}.png"
+
+    def test_extra_state_attributes_location(self):
+        coord = _make_coordinator(rain_station="S77")
+        sensor = NeaRainSensor(coord, _make_config(), "S77", "entry1")
+        attrs = sensor.extra_state_attributes
+        assert "latitude" in attrs
+        assert "longitude" in attrs
+        assert "Location name" in attrs
+        assert attrs["Location name"] == "Alexandra Road"
+
+    def test_extra_state_attributes_timestamp(self):
+        coord = _make_coordinator(rain_station="S77", rain_timestamp="2024-03-01T08:00:00+08:00")
+        sensor = NeaRainSensor(coord, _make_config(), "S77", "entry1")
+        assert sensor.extra_state_attributes["Updated at"] == "2024-03-01T08:00:00+08:00"
+
+
+# ---------------------------------------------------------------------------
+# NeaUVSensor
+# ---------------------------------------------------------------------------
+
+class TestNeaUVSensor:
+    def test_unique_id(self):
+        coord = _make_coordinator()
+        sensor = NeaUVSensor(coord, _make_config("nea"), "entry1")
+        assert sensor.unique_id == "nea_uv"
+
+    def test_name(self):
+        coord = _make_coordinator()
+        sensor = NeaUVSensor(coord, _make_config(), "entry1")
+        assert sensor.name == "UV Index in Singapore"
+
+    def test_entity_id(self):
+        coord = _make_coordinator()
+        sensor = NeaUVSensor(coord, _make_config("nea"), "entry1")
+        assert sensor.entity_id == "sensor.nea_uv"
+
+    def test_native_value(self):
+        coord = _make_coordinator(uv_index=8)
+        sensor = NeaUVSensor(coord, _make_config(), "entry1")
+        assert sensor.native_value == 8
+
+    def test_native_value_zero(self):
+        coord = _make_coordinator(uv_index=0)
+        sensor = NeaUVSensor(coord, _make_config(), "entry1")
+        assert sensor.native_value == 0
+
+
+# ---------------------------------------------------------------------------
+# NeaPM25Sensor
+# ---------------------------------------------------------------------------
+
+class TestNeaPM25Sensor:
+    def test_unique_id(self):
+        coord = _make_coordinator()
+        sensor = NeaPM25Sensor(coord, _make_config("nea"), "West", "entry1")
+        assert sensor.unique_id == "nea pm25 West"
+
+    def test_name_non_central(self):
+        coord = _make_coordinator()
+        sensor = NeaPM25Sensor(coord, _make_config(), "West", "entry1")
+        assert sensor.name == "PM 2.5 Readings in Western Singapore"
+
+    def test_name_central(self):
+        coord = _make_coordinator()
+        sensor = NeaPM25Sensor(coord, _make_config(), "Central", "entry1")
+        assert sensor.name == "PM 2.5 Readings in Central Singapore"
+
+    def test_name_east(self):
+        coord = _make_coordinator()
+        sensor = NeaPM25Sensor(coord, _make_config(), "East", "entry1")
+        assert sensor.name == "PM 2.5 Readings in Eastern Singapore"
+
+    def test_native_value(self):
+        pm25_data = {"west": 15, "east": 18, "central": 12, "south": 10, "north": 14}
+        coord = _make_coordinator(pm25_data=pm25_data)
+        sensor = NeaPM25Sensor(coord, _make_config(), "West", "entry1")
+        assert sensor.native_value == 15
+
+    def test_entity_id(self):
+        coord = _make_coordinator()
+        sensor = NeaPM25Sensor(coord, _make_config("nea"), "North", "entry1")
+        assert sensor.entity_id == "sensor.nea_pm25north"


### PR DESCRIPTION
- tests/conftest.py: lightweight Home Assistant module stubs (no HA install needed)
- tests/test_const.py: validates AREAS (47), REGIONS (5), condition mappings,
  icon codes, rain sensor list coordinates, and API endpoints
- tests/test_nea.py: tests data-processing logic for Forecast2hr, Forecast24hr,
  Forecast4day, Temperature, Humidity, UVIndex, PM25, Wind.calc_wind_status,
  Rain; also documents ZeroDivisionError limitation in calc_wind_status
- tests/test_init.py: tests get_platforms() platform/entity selection for all
  configuration combinations
- tests/test_sensor.py: tests entity properties (name, unique_id, entity_id,
  state, attributes, entity_picture thresholds) for all 5 sensor classes
- pytest.ini: configure testpaths and asyncio mode
- requirements-test.txt: pytest + pytest-asyncio
- .github/workflows/tests.yml: CI on Python 3.11 and 3.12
- CLAUDE.md: developer guide explaining how to run tests and project layout

https://claude.ai/code/session_01CEN6jdo8Zkiicg5GiLffi9