### PR TITLE
Remove orphaned rain sensors when station list changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,11 @@ custom_components/nea_sg_weather/
 
 Rain station entities are built from the live API response (`Rain.station_list`) rather than a static list. This means the set of stations can change between coordinator updates.
 
-`sensor.py:async_setup_entry` handles this with a coordinator listener registered after initial entity creation:
+`sensor.py:async_setup_entry` handles this in two stages:
+
+**Startup cleanup** — before creating any entities, all rain sensor entries already in the entity registry for this config entry are scanned. Any whose station ID is not in the current API `station_list` are removed immediately. This catches orphans left behind by previous installs or a static station list.
+
+**Runtime listener** — a coordinator listener registered after initial entity creation diffs `_known_rain_ids` on every update:
 
 - **Removed stations** — looked up in the entity registry by `unique_id` and deleted via `entity_registry.async_remove()` so they do not remain as orphans in HA.
 - **New stations** — instantiated as `NeaRainSensor` and registered via `async_add_entities()`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,17 @@ custom_components/nea_sg_weather/
 └── config_flow.py    # Config-entry UI flow
 ```
 
+## Dynamic Rain Sensor Management
+
+Rain station entities are built from the live API response (`Rain.station_list`) rather than a static list. This means the set of stations can change between coordinator updates.
+
+`sensor.py:async_setup_entry` handles this with a coordinator listener registered after initial entity creation:
+
+- **Removed stations** — looked up in the entity registry by `unique_id` and deleted via `entity_registry.async_remove()` so they do not remain as orphans in HA.
+- **New stations** — instantiated as `NeaRainSensor` and registered via `async_add_entities()`.
+
+`NeaRainSensor.available` returns `False` when the station ID is absent from `coordinator.data.rain.data`, preventing `KeyError` crashes in the brief window between a station disappearing from the API and its entity being removed.
+
 ## CI
 
 GitHub Actions (`.github/workflows/tests.yml`) runs the suite on Python 3.11

--- a/README.md
+++ b/README.md
@@ -14,11 +14,12 @@ Add this integration to Home Assistant using HACS, or copy everything in `custom
 
 Follow the integration config flow to set up the following entities:
 - `weather`: weather entity with 4 day forecasts
-- `area` (town) sensors: current weather conditions for up to 47 areas/towns in Singapore 
-- `region` sensors: 24 weather condition forecast for North/South/East/West/Central regions of Singapore
-- `rain` camera: 2 camera entities for static and animated rain map overlays that are updated every 5 minutes from NEA
+- `area` (town) sensors: current weather conditions for up to 47 areas/towns in Singapore
+- `region` sensors: 24 hour weather condition forecast for North/South/East/West/Central regions of Singapore
+- `rain` camera: 2 camera entities for static and animated rain map overlays updated every 5 minutes from NEA
+- `rain` sensors: one rainfall sensor per active NEA station, fetched live from the API — stations are added and removed automatically as the API changes
 - `pm25` sensors: 5 pm2.5 sensors for North/South/East/West/Central regions of Singapore
-- `uv_index` sensor: 1 uv index for Singapore
+- `uv_index` sensor: UV index for Singapore
 
 
 ## Weather Map Overlays
@@ -34,10 +35,11 @@ For the overlays to display properly, you will need the `area`, `region` and `ra
 
 Instructions for how to integrate the `yaml` files are included in the various files in the `nea_sg_weather/yaml` folder.
 
-## Rainfall map
+## Rainfall sensors
 
-Starting in v1.5, rainfall sensors have location attributes.
-Users can display sensors on a map card in Lovelace UI.
+Rainfall sensors are created dynamically from the live NEA API — no static station list is used. Orphaned sensors (stations decommissioned by NEA) are automatically removed from Home Assistant on startup and whenever the station list changes at runtime.
+
+Sensors include location attributes so they can be displayed on a Lovelace map card.
 
 For entity pictures to display correctly, copy all image files in `www/weather/` to your `config/www/weather/` folder.
 ![image](https://user-images.githubusercontent.com/57534857/171048147-5e6dcfd3-40c4-4eff-a09c-f1f6c31ddb92.png)

--- a/custom_components/nea_sg_weather/sensor.py
+++ b/custom_components/nea_sg_weather/sensor.py
@@ -69,12 +69,23 @@ async def async_setup_entry(
     # add rainfall sensor entities
     if config_entry.data[CONF_SENSORS][CONF_RAIN]:
         _known_rain_ids: set[str] = {s["id"] for s in coordinator.data.rain.station_list}
+        prefix = config_entry.data[CONF_SENSORS][CONF_PREFIX]
+
+        # Remove orphaned rain sensor entities from previous installs whose
+        # station IDs are no longer present in the current API response.
+        ent_reg = er.async_get(hass)
+        _rainfall_prefix = f"{prefix} Rainfall "
+        for entry in er.async_entries_for_config_entry(ent_reg, entry_id):
+            if entry.unique_id.startswith(_rainfall_prefix):
+                sid = entry.unique_id[len(_rainfall_prefix):]
+                if sid not in _known_rain_ids:
+                    ent_reg.async_remove(entry.entity_id)
+                    _LOGGER.debug("Removed orphaned rain sensor on startup: %s", sid)
+
         entities_list += [
             NeaRainSensor(coordinator, config_entry.data, sid, entry_id)
             for sid in _known_rain_ids
         ]
-
-        prefix = config_entry.data[CONF_SENSORS][CONF_PREFIX]
 
         def _make_rain_listener(
             known: set[str],

--- a/custom_components/nea_sg_weather/sensor.py
+++ b/custom_components/nea_sg_weather/sensor.py
@@ -20,6 +20,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import NeaWeatherDataUpdateCoordinator
@@ -67,10 +68,47 @@ async def async_setup_entry(
 
     # add rainfall sensor entities
     if config_entry.data[CONF_SENSORS][CONF_RAIN]:
+        _known_rain_ids: set[str] = {s["id"] for s in coordinator.data.rain.station_list}
         entities_list += [
-            NeaRainSensor(coordinator, config_entry.data, rain_sensor_id["id"], entry_id)
-            for rain_sensor_id in coordinator.data.rain.station_list
+            NeaRainSensor(coordinator, config_entry.data, sid, entry_id)
+            for sid in _known_rain_ids
         ]
+
+        prefix = config_entry.data[CONF_SENSORS][CONF_PREFIX]
+
+        def _make_rain_listener(
+            known: set[str],
+            add_cb: AddEntitiesCallback,
+        ):
+            def _listener():
+                current = {s["id"] for s in coordinator.data.rain.station_list}
+                removed = known - current
+                added = current - known
+
+                if removed:
+                    ent_reg = er.async_get(hass)
+                    for sid in removed:
+                        unique_id = f"{prefix} Rainfall {sid}"
+                        entity_id = ent_reg.async_get_entity_id("sensor", DOMAIN, unique_id)
+                        if entity_id:
+                            ent_reg.async_remove(entity_id)
+                            _LOGGER.debug("Removed orphaned rain sensor: %s", sid)
+                    known.difference_update(removed)
+
+                if added:
+                    new_entities = [
+                        NeaRainSensor(coordinator, config_entry.data, sid, entry_id)
+                        for sid in added
+                    ]
+                    add_cb(new_entities)
+                    _LOGGER.debug("Added new rain sensors: %s", added)
+                    known.update(added)
+
+            return _listener
+
+        coordinator.async_add_listener(
+            _make_rain_listener(_known_rain_ids, async_add_entities)
+        )
 
     # add uv sensor entities
     entities_list += [
@@ -323,6 +361,14 @@ class NeaRainSensor(CoordinatorEntity, SensorEntity):
     def unique_id(self):
         """Return the unique ID."""
         return self._prefix + " Rainfall " + self._rain_sensor_id
+
+    @property
+    def available(self) -> bool:
+        """Return False if this station is no longer in the API data."""
+        return (
+            super().available
+            and self._rain_sensor_id in self.coordinator.data.rain.data
+        )
 
     @property
     def name(self):

--- a/custom_components/nea_sg_weather/sensor.py
+++ b/custom_components/nea_sg_weather/sensor.py
@@ -117,8 +117,10 @@ async def async_setup_entry(
 
             return _listener
 
-        coordinator.async_add_listener(
-            _make_rain_listener(_known_rain_ids, async_add_entities)
+        config_entry.async_on_unload(
+            coordinator.async_add_listener(
+                _make_rain_listener(_known_rain_ids, async_add_entities)
+            )
         )
 
     # add uv sensor entities

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,10 @@ class _CoordinatorEntity:
     def __init__(self, coordinator=None):
         self.coordinator = coordinator
 
+    @property
+    def available(self) -> bool:
+        return self.coordinator.last_update_success
+
 
 class _DataUpdateCoordinator:
     def __init__(self, *args, **kwargs):

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -260,6 +260,19 @@ class TestNeaRainSensor:
         sensor = NeaRainSensor(coord, _make_config(), "S77", "entry1")
         assert sensor.extra_state_attributes["Updated at"] == "2024-03-01T08:00:00+08:00"
 
+    def test_available_when_station_in_data(self):
+        coord = _make_coordinator(rain_station="S77")
+        coord.last_update_success = True
+        sensor = NeaRainSensor(coord, _make_config(), "S77", "entry1")
+        assert sensor.available is True
+
+    def test_available_false_when_station_missing_from_data(self):
+        coord = _make_coordinator(rain_station="S77")
+        coord.last_update_success = True
+        sensor = NeaRainSensor(coord, _make_config(), "S99", "entry1")
+        # S99 is not in rain.data (only S77 is), so sensor should be unavailable
+        assert sensor.available is False
+
 
 # ---------------------------------------------------------------------------
 # NeaUVSensor


### PR DESCRIPTION
- Register a coordinator listener in async_setup_entry that diffs the
  current station list against known IDs on every update: removes entity-
  registry entries for stations that disappeared and calls async_add_entities
  for newly discovered stations.
- Add NeaRainSensor.available that returns False when the station ID is
  absent from coordinator.data.rain.data, preventing KeyErrors during the
  transition window before the entity is removed.
- Add available property to _CoordinatorEntity test stub and two new tests
  covering the available guard.

https://claude.ai/code/session_018LBb196XLxMQ8Sx29XM3db